### PR TITLE
src/pGroupCohomology/cohomology.pyx: Update import of instancedoc

### DIFF
--- a/src/pGroupCohomology/cohomology.pyx
+++ b/src/pGroupCohomology/cohomology.pyx
@@ -68,7 +68,7 @@ from sage.all import mul
 from sage.env import DOT_SAGE, SAGE_ROOT
 from sage.misc.sageinspect import sage_getargspec
 from sage.misc.lazy_attribute import lazy_attribute
-from sage.docs.instancedoc import instancedoc
+from sage.misc.instancedoc import instancedoc
 from sage.structure.richcmp import richcmp, richcmp_method, op_LT, op_NE, op_GT
 
 # Sage rings etc.


### PR DESCRIPTION
for Sage 9.7, to fix https://trac.sagemath.org/ticket/30787#comment:109
